### PR TITLE
feat(webapp): expose verification error reason via public API

### DIFF
--- a/apps/webapp/src/app/api/task/[task-id]/route.ts
+++ b/apps/webapp/src/app/api/task/[task-id]/route.ts
@@ -1,11 +1,11 @@
 import {type NextRequest, NextResponse} from 'next/server'
 
 import {addCorsHeaders, corsPreflight} from '@/lib/cors'
-import {getLatestReportedTaskForApp} from '@/lib/db'
+import {getTaskApiInfoById} from '@/lib/db'
 
 interface RouteParams {
   params: Promise<{
-    'app-id': string
+    'task-id': string
   }>
 }
 
@@ -14,23 +14,24 @@ export async function OPTIONS(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest, {params}: RouteParams) {
-  const {'app-id': appId} = await params
+  const {'task-id': taskId} = await params
   const origin = request.headers.get('origin')
 
-  const task = await getLatestReportedTaskForApp(appId)
+  const task = await getTaskApiInfoById(taskId)
 
   if (!task) {
-    const response = NextResponse.json({error: 'App not found'}, {status: 404})
+    const response = NextResponse.json({error: 'Task not found'}, {status: 404})
     response.headers.set('Cache-Control', 'no-store')
     return addCorsHeaders(response, origin)
   }
 
   const response = NextResponse.json({
-    id: appId,
+    id: task.taskId,
+    appId: task.appId,
     status: task.status,
-    taskId: task.taskId,
     errorMessage: task.errorMessage,
     verificationFlags: task.verificationFlags,
+    createdAt: task.createdAt,
     startedAt: task.startedAt,
     finishedAt: task.finishedAt,
   })

--- a/apps/webapp/src/lib/cors.ts
+++ b/apps/webapp/src/lib/cors.ts
@@ -1,0 +1,42 @@
+import {NextResponse} from 'next/server'
+
+const ALLOWED_ORIGIN_PATTERNS = [
+  /^https?:\/\/[a-zA-Z0-9-]+\.phala\.network$/,
+  /^https?:\/\/[a-zA-Z0-9-]+\.phala\.com$/,
+  /^https?:\/\/.*\.?localhost(:\d+)?$/,
+]
+
+const FRAME_ANCESTORS = [
+  '*.phala.network',
+  '*.phala.com',
+  '*.localhost:*',
+  'localhost:*',
+]
+
+export function isAllowedOrigin(origin: string | null): boolean {
+  if (!origin) return false
+  return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin))
+}
+
+export function addCorsHeaders(
+  response: NextResponse,
+  origin: string | null,
+  methods = 'GET, OPTIONS',
+) {
+  if (origin && isAllowedOrigin(origin)) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.set('Access-Control-Allow-Methods', methods)
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type')
+  }
+
+  response.headers.set(
+    'Content-Security-Policy',
+    `frame-ancestors ${FRAME_ANCESTORS.join(' ')}`,
+  )
+
+  return response
+}
+
+export function corsPreflight(origin: string | null) {
+  return addCorsHeaders(new NextResponse(null, {status: 204}), origin)
+}

--- a/apps/webapp/src/lib/db.ts
+++ b/apps/webapp/src/lib/db.ts
@@ -12,6 +12,7 @@ import {
   sql,
   type Task,
   type VerificationFlags,
+  type VerificationTaskStatus,
   verificationTasksTable,
 } from '@phala/trust-center-db'
 
@@ -880,3 +881,94 @@ export async function getTask(
 export type AppProfile = ProfileDisplay
 export type WorkspaceProfile = ProfileDisplay
 export type UserProfile = ProfileDisplay
+
+// Compact task info returned by the public REST API routes.
+// Separate from AppWithTask (which carries profile/join data we don't expose).
+export interface TaskApiInfo {
+  taskId: string
+  appId: string
+  status: VerificationTaskStatus
+  errorMessage: string | null
+  verificationFlags: VerificationFlags | null
+  createdAt: string
+  startedAt: string | null
+  finishedAt: string | null
+}
+
+const taskApiSelection = {
+  id: verificationTasksTable.id,
+  appId: verificationTasksTable.appId,
+  status: verificationTasksTable.status,
+  errorMessage: verificationTasksTable.errorMessage,
+  verificationFlags: verificationTasksTable.verificationFlags,
+  createdAt: verificationTasksTable.createdAt,
+  startedAt: verificationTasksTable.startedAt,
+  finishedAt: verificationTasksTable.finishedAt,
+}
+
+function toTaskApiInfo(row: {
+  id: string
+  appId: string
+  status: VerificationTaskStatus
+  errorMessage: string | null
+  verificationFlags: unknown
+  createdAt: Date
+  startedAt: Date | null
+  finishedAt: Date | null
+}): TaskApiInfo {
+  return {
+    taskId: row.id,
+    appId: row.appId,
+    status: row.status,
+    errorMessage: row.errorMessage,
+    verificationFlags:
+      (row.verificationFlags as VerificationFlags | null) ?? null,
+    createdAt: row.createdAt.toISOString(),
+    startedAt: row.startedAt?.toISOString() ?? null,
+    finishedAt: row.finishedAt?.toISOString() ?? null,
+  }
+}
+
+async function fetchLatestTaskByStatus(
+  appId: string,
+  status: VerificationTaskStatus,
+): Promise<TaskApiInfo | null> {
+  const rows = await db
+    .select(taskApiSelection)
+    .from(verificationTasksTable)
+    .where(
+      and(
+        eq(verificationTasksTable.appId, appId),
+        eq(verificationTasksTable.status, status),
+      ),
+    )
+    .orderBy(desc(verificationTasksTable.createdAt))
+    .limit(1)
+
+  return rows[0] ? toTaskApiInfo(rows[0]) : null
+}
+
+// Returns the task result for a given app, preferring the latest 'completed' task
+// over the latest 'failed' one. Used by the public GET /api/app/[app-id] endpoint.
+// Returns null if the app has neither a completed nor a failed task.
+export async function getLatestReportedTaskForApp(
+  appId: string,
+): Promise<TaskApiInfo | null> {
+  const completed = await fetchLatestTaskByStatus(appId, 'completed')
+  if (completed) return completed
+  return fetchLatestTaskByStatus(appId, 'failed')
+}
+
+// Returns a single task by its ID with no status filtering.
+// Used by the public GET /api/task/[task-id] endpoint.
+export async function getTaskApiInfoById(
+  taskId: string,
+): Promise<TaskApiInfo | null> {
+  const rows = await db
+    .select(taskApiSelection)
+    .from(verificationTasksTable)
+    .where(eq(verificationTasksTable.id, taskId))
+    .limit(1)
+
+  return rows[0] ? toTaskApiInfo(rows[0]) : null
+}


### PR DESCRIPTION
## Summary
- `GET /api/app/[app-id]` now prefers the latest **completed** task and falls back to the latest **failed** task so consumers can learn why the last verification attempt failed. Response adds `taskId`, `errorMessage`, `verificationFlags`, `startedAt`, `finishedAt`; sets `Cache-Control: no-store`.
- Adds new `GET /api/task/[task-id]` for task-centric lookups (same response shape, plus `appId` and `createdAt`).
- Extracts CORS/CSP helpers into `apps/webapp/src/lib/cors.ts` so both routes share one allow-list and `frame-ancestors` policy.
- Adds slim DB helpers (`getLatestReportedTaskForApp`, `getTaskApiInfoById`) scoped to the public API; existing `getApp` / `getTaskById` are intentionally untouched to preserve the latest-completed-with-profile-joins semantics relied on by the page/embed/opengraph routes.

No DB schema, verifier, or worker changes.

### Behavior change to call out
Previously `GET /api/app/[app-id]` returned 200 only when a completed task existed (else 404), and `status` was always `completed`. It can now return 200 with `status: 'failed'` and a populated `errorMessage`. `pending`, `active`, and `cancelled` tasks are intentionally ignored — the endpoint reports only the latest *result*.

### Example responses

`/api/app/0xabc...` — failed fallback
```json
{
  "id": "0xabc...",
  "status": "failed",
  "taskId": "7f3c...-uuid",
  "errorMessage": "Failed to fetch attestation quote: timeout after 30s",
  "verificationFlags": { "hardware": true, "os": true, "sourceCode": true, "domainOwnership": false },
  "startedAt": "2026-04-21T08:12:03.000Z",
  "finishedAt": "2026-04-21T08:12:34.000Z"
}
```

`/api/task/<task-id>`
```json
{
  "id": "7f3c...-uuid",
  "appId": "0xabc...",
  "status": "failed",
  "errorMessage": "...",
  "verificationFlags": { ... },
  "createdAt": "...",
  "startedAt": "...",
  "finishedAt": "..."
}
```

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run --filter @phala/trust-center-webapp build` — clean (new routes appear in the route table)
- [x] Biome clean on the four touched files
- [ ] Smoke-test both endpoints against a staging DB: verify completed-priority, failed-fallback, 404 when neither exists
- [ ] Confirm CORS allow-list still honored from `*.phala.network` / `*.phala.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)