### PR TITLE
feat(webapp): show attestation time with minute precision

### DIFF
--- a/apps/webapp/src/app/_components/app-list.tsx
+++ b/apps/webapp/src/app/_components/app-list.tsx
@@ -121,10 +121,13 @@ const AppCard = memo(function AppCard({app}: {app: AppWithTask}) {
           </span>
           <div className="flex items-center gap-2 flex-1 flex-wrap">
             <span className="text-muted-foreground">
-              {new Date(app.task.createdAt).toLocaleDateString('en-US', {
+              {new Date(app.task.createdAt).toLocaleString('en-US', {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
               })}
             </span>
             {/* {stale && (

--- a/apps/webapp/src/components/visualization/report-components.tsx
+++ b/apps/webapp/src/components/visualization/report-components.tsx
@@ -175,10 +175,13 @@ export const ReportHeader: React.FC<{
               Attestation Time
             </span>
             <span className="text-muted-foreground">
-              {new Date(app.task.createdAt).toLocaleDateString('en-US', {
+              {new Date(app.task.createdAt).toLocaleString('en-US', {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
               })}
             </span>
           </div>


### PR DESCRIPTION
## Summary
- Display task `createdAt` with hour/minute (24h) on the app list card ("Created") and the report header ("Attestation Time"). Previously only date was shown, e.g. `Apr 29, 2026` — now `Apr 29, 2026, 14:23`.
- Format stays consistent with existing `en-US` locale style. Switch to `toLocaleString` with `hour: '2-digit'`, `minute: '2-digit'`, `hour12: false`.

## Test plan
- [ ] Open app list page — every card's "Created" row shows `<date>, HH:MM`
- [ ] Open a report page — header "Attestation Time" shows `<date>, HH:MM`
- [ ] Verify it renders correctly across timezones (uses browser locale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)