### PR TITLE
fix(verifier): include failures when computing response.success (closes #33)

### DIFF
--- a/packages/verifier/src/verificationService.ts
+++ b/packages/verifier/src/verificationService.ts
@@ -189,7 +189,7 @@ export class VerificationService {
       ? maskSensitiveDataObjects(dataObjects)
       : dataObjects
 
-    const success = this.errors.length === 0
+    const success = this.errors.length === 0 && this.failures.length === 0
 
     return {
       dataObjects: finalDataObjects,


### PR DESCRIPTION
## Summary

Fixes #33.

`VerificationService.buildResponse()` set `success = this.errors.length === 0` and shipped it alongside a populated `failures` array. So any verification step that completed but failed its check (hardware / OS / sourceCode, and the GatewayVerifier domain checks: teeControlledKey, certificateKey, dnsCAA, ctLog) was correctly added to `failures` but still left `success: true` on the top-level response.

That contradicts how `README.md` and SDK consumers use `result.success` as the pass/fail bit (`if (result.success) console.log('Verification passed!')`).

Fix: `success` now requires both `errors` and `failures` to be empty.

```diff
- const success = this.errors.length === 0
+ const success = this.errors.length === 0 && this.failures.length === 0
```

`executeVerifiers` in `verifierChain.ts` returns its own `success` field with the same bug, but that field is dead — `verificationService.ts` only consumes `result.errors` / `result.failures` and recomputes its own. Left untouched to keep the diff minimal; can drop the dead field in a follow-up if desired.

## Test plan

- [x] `bun run typecheck` (root) — passes (turbo, 4/4 packages)
- [ ] Manual: run a verification where a Gateway domain check fails (e.g. DNS CAA misconfig) and confirm response has `success: false` and the corresponding entry in `failures[]`
