### PR TITLE
fix: pin dcap-qvl builder to bookworm + accept null instance quote (prod incident)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN bun install
 # ------------------------------------------------------------------------------
 
 # dcap-qvl: Intel DCAP Quote Verification Library (Rust)
-FROM rust:1.89-slim AS dcap-qvl-builder
+FROM rust:1.89-slim-bookworm AS dcap-qvl-builder
 RUN apt-get update && \
     apt-get install -y build-essential pkg-config libssl-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -127,6 +127,14 @@ RUN chmod +x \
     /usr/local/bin/dstack-mr-cli \
     /usr/local/bin/dstack-mr \
     /usr/local/bin/dstack-acpi-tables
+
+# ABI smoke test - exercises the dynamic linker so any glibc / shared-lib
+# mismatch between a builder stage and this runtime base fails the build
+# instead of leaking to production.
+RUN dcap-qvl --version \
+ && dstack-mr-cli --version \
+ && dstack-mr --version \
+ && dstack-acpi-tables --version > /dev/null
 
 # ------------------------------------------------------------------------------
 # Stage 5: Final Image - Application

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,13 +128,19 @@ RUN chmod +x \
     /usr/local/bin/dstack-mr \
     /usr/local/bin/dstack-acpi-tables
 
-# ABI smoke test - exercises the dynamic linker so any glibc / shared-lib
-# mismatch between a builder stage and this runtime base fails the build
-# instead of leaking to production.
-RUN dcap-qvl --version \
- && dstack-mr-cli --version \
- && dstack-mr --version \
- && dstack-acpi-tables --version > /dev/null
+# ABI smoke test - invokes each binary so the dynamic linker runs. Greps
+# stderr for the known linker / glibc error patterns instead of relying on
+# any specific exit code, because the binaries differ in CLI conventions
+# (dcap-qvl uses clap subcommands and rejects bare --help/--version,
+# qemu accepts both, etc.). Catches the exact failure mode of the
+# rust:1.89-slim trixie -> bookworm regression at build time.
+RUN set -e; \
+    for bin in dcap-qvl dstack-mr-cli dstack-mr dstack-acpi-tables; do \
+      err=$("$bin" --help 2>&1 1>/dev/null || true); \
+      if echo "$err" | grep -qE 'GLIBC|undefined symbol|error while loading|cannot open shared'; then \
+        echo "ABI failure for $bin:"; echo "$err"; exit 1; \
+      fi; \
+    done
 
 # ------------------------------------------------------------------------------
 # Stage 5: Final Image - Application

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ FROM deps AS runtime
 
 # Install runtime dependencies for QEMU
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libglib2.0-0 libslirp0 && \
+    apt-get install -y --no-install-recommends libglib2.0-0 libslirp0 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy verification tool binaries

--- a/packages/verifier/src/schemas.ts
+++ b/packages/verifier/src/schemas.ts
@@ -61,7 +61,7 @@ export const InstanceTcbInfoSchema = z.object({
  */
 export const DstackInstanceSchema = z
   .object({
-    quote: z.string().optional(),
+    quote: z.string().nullish(),
     // Old format: top-level eventlog
     eventlog: EventLogSchema.optional(),
     // New format: tcb_info with nested event_log

--- a/packages/verifier/src/verifiers/phalaCloudVerifier.ts
+++ b/packages/verifier/src/verifiers/phalaCloudVerifier.ts
@@ -256,7 +256,7 @@ export class PhalaCloudVerifier extends Verifier {
 			// Filter out invalid instances (empty objects when instance is turned off)
 			const validInstances = parseResult.data.instances.filter(
 				(instance) =>
-					instance.quote !== undefined &&
+					instance.quote !== undefined && instance.quote !== null &&
 					instance.eventlog !== undefined &&
 					instance.image_version !== undefined,
 			);


### PR DESCRIPTION
## Summary

End-to-end fix for the trust-center prod incident on 2026-05-20 (every verification failing). Scope grew during minis-side validation as each layer fix unmasked the next, but they are all symptoms of the same underlying release and all targeted at one Dockerfile + one verifier.

### Three independent prod bugs, all surfaced by the same deploy

| Layer | Symptom in prod log | Root cause | Fix |
|-------|---------------------|------------|-----|
| Runtime ABI | `dcap-qvl: GLIBC_2.38 not found` | `FROM rust:1.89-slim` was the only Dockerfile stage without a pinned base; Docker Hub rolled the tag from bookworm to trixie (glibc 2.41), runtime base stayed on bookworm (glibc 2.36) | Pin builder to `rust:1.89-slim-bookworm` (7832ee7) |
| TLS / runtime deps | `No CA certificates were loaded from the system` (masked by GLIBC) | `oven/bun:1.3.0-slim` does not ship `/etc/ssl/certs/ca-certificates.crt`; dcap-qvl can't TLS to PCCS | `apt-get install ca-certificates` in runtime stage (52bcac3) |
| Wire-format contract | `Invalid input: expected string, received null at path: ...quote` | cloud-api emits `quote: null` for instances without `app_certificates` (since 2026-03-04). Trust-center's `DstackInstanceSchema.quote` was `z.string().optional()` which accepts undefined but not null. Filter on line 257 then also only checked `!== undefined`, so even after relaxing the schema, null slips into the transform and `null.startsWith(...)` throws. | `quote: z.string().nullish()` (2a8ed63) **and** filter excludes null (cf741a0) |

### CI gate added alongside the fixes

The GLIBC mismatch was undetectable by the existing CI because typecheck runs on GitHub Actions ubuntu-latest (newer glibc), not the final image. Added an ABI smoke test as the last RUN of the runtime stage that exercises the dynamic linker for every copied binary and greps stderr for known glibc / shared-lib failure patterns. This was initially written as `--version` checks but dcap-qvl uses clap top-level subcommands and rejects bare `--version`; rewrote to be CLI-convention-agnostic (1441a3c).

This gate would have caught the original incident at build time before any merge.

### Commits

```
cf741a0  fix(verifier): exclude null-quote instances from validInstances filter
52bcac3  fix(docker): install ca-certificates in runtime stage
1441a3c  fix(docker): make ABI smoke test grep stderr instead of trusting --version
2a8ed63  fix(schema): accept null `quote` on DstackInstance
7832ee7  fix(docker): pin rust:1.89-slim to bookworm + add ABI smoke test
```

### Companion PR (already merged)

[Phala-Network/phala-cloud-monorepo#1458](https://github.com/Phala-Network/phala-cloud-monorepo/pull/1458) locks down the cloud-api half of the `instances[].quote = null` contract with an integration test so the next person changing `attestations.py` cannot silently drift the wire format.

## Test plan

- [x] `bun run typecheck` (root, all 4 packages) — pass
- [x] `docker build` via GHCR workflow — pass (will be re-verified on this push)
- [x] **End-to-end verification on minis** with new image + 9 prod apps representing 4 distinct conditions:
  - 6 apps with `quote=hex` + running instance (mix of PHALA and Base on-chain KMS) → all 6 ✅ `Verification completed` in 19–35 s
  - 2 apps with all attestation fields missing on the wire → 2 ⚠️ `no running instances` (expected, pre-existing behavior preserved)
  - 1 app with `quote=null` + all other fields populated (`480c24ebfdf44d31d8c824c5e7fd6d88afe9038b`) → 1 ⚠️ `no running instances` (this case crashed with `null is not an object (evaluating 'instance.quote.startsWith')` before cf741a0; now classified correctly)
  - 0 GLIBC errors, 0 CA cert errors, 0 zod parse failures, 0 TypeErrors
- [ ] After merge + deploy: spot-check prod (in particular any app where the previous deploy was failing) to confirm `success: true`
