### PR TITLE
fix: handle nullable Cloud quotes and dcap runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ RUN bun install
 # ------------------------------------------------------------------------------
 
 # dcap-qvl: Intel DCAP Quote Verification Library (Rust)
-FROM rust:1.89-slim AS dcap-qvl-builder
+# Build on Debian bookworm so the binary links against a glibc compatible with
+# the oven/bun:1.3.0-slim runtime image.
+FROM rust:1.89.0-slim-bookworm AS dcap-qvl-builder
 RUN apt-get update && \
     apt-get install -y build-essential pkg-config libssl-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -127,6 +129,9 @@ RUN chmod +x \
     /usr/local/bin/dstack-mr-cli \
     /usr/local/bin/dstack-mr \
     /usr/local/bin/dstack-acpi-tables
+
+# Catch dcap-qvl dynamic linker/glibc mismatches while building the image.
+RUN /usr/local/bin/dcap-qvl --help >/dev/null
 
 # ------------------------------------------------------------------------------
 # Stage 5: Final Image - Application

--- a/packages/verifier/src/schemas.ts
+++ b/packages/verifier/src/schemas.ts
@@ -61,13 +61,14 @@ export const InstanceTcbInfoSchema = z.object({
  */
 export const DstackInstanceSchema = z
   .object({
-    quote: z.string().optional(),
+    quote: z.string().nullable().optional(),
     // Old format: top-level eventlog
-    eventlog: EventLogSchema.optional(),
+    eventlog: EventLogSchema.nullable().optional(),
     // New format: tcb_info with nested event_log
-    tcb_info: InstanceTcbInfoSchema.optional(),
+    tcb_info: InstanceTcbInfoSchema.nullable().optional(),
     image_version: z
       .string()
+      .nullable()
       .optional()
       .transform((val) => {
         if (!val) return val

--- a/packages/verifier/src/verifiers/phalaCloudVerifier.test.ts
+++ b/packages/verifier/src/verifiers/phalaCloudVerifier.test.ts
@@ -1,0 +1,93 @@
+import {afterEach, describe, expect, test} from 'bun:test'
+
+import {DstackInstanceSchema} from '../schemas'
+import type {AppId} from '../types'
+import {PhalaCloudVerifier} from './phalaCloudVerifier'
+
+const originalFetch = globalThis.fetch
+
+function mockCloudAttestationsResponse(body: unknown) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: {'content-type': 'application/json'},
+    })) as unknown as typeof fetch
+}
+
+function makeSystemInfoPayload(instances: unknown[]) {
+  return {
+    app_id: 'abcd',
+    contract_address: null,
+    kms_info: {
+      contract_address: null,
+      chain_id: null,
+      version: 'v0.5.3 (git:abc123)',
+      url: 'https://kms.example.test',
+      gateway_app_id: null,
+      gateway_app_url: 'https://gateway.example.test',
+    },
+    instances,
+  }
+}
+
+describe('PhalaCloudVerifier attestations parsing', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('accepts nullable instance fields from stopped instances', () => {
+    const result = DstackInstanceSchema.safeParse({
+      quote: null,
+      eventlog: null,
+      tcb_info: null,
+      image_version: null,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test('filters nullable quote instances before quote normalization', async () => {
+    mockCloudAttestationsResponse(
+      makeSystemInfoPayload([
+        {
+          quote: null,
+          eventlog: [],
+          image_version: 'dstack-0.5.3',
+        },
+        {
+          quote: 'abc123',
+          eventlog: [],
+          image_version: 'dstack-0.5.3',
+        },
+      ]),
+    )
+
+    const systemInfo = await PhalaCloudVerifier.getSystemInfo('abcd' as AppId)
+
+    expect(systemInfo.instances).toHaveLength(1)
+    expect(systemInfo.instances[0]?.quote).toBe('0xabc123')
+    expect(systemInfo.instances[0]?.eventlog).toEqual([])
+    expect(String(systemInfo.instances[0]?.image_version)).toBe('dstack-0.5.3')
+  })
+
+  test('reports no running instances when every parsed instance is invalid', async () => {
+    mockCloudAttestationsResponse(
+      makeSystemInfoPayload([
+        {
+          quote: null,
+          eventlog: [],
+          image_version: 'dstack-0.5.3',
+        },
+        {
+          quote: 'abc123',
+          eventlog: null,
+          image_version: null,
+        },
+      ]),
+    )
+
+    await expect(
+      PhalaCloudVerifier.getSystemInfo('abcd' as AppId),
+    ).rejects.toThrow("App 'abcd' has no running instances on Phala Cloud")
+  })
+})

--- a/packages/verifier/src/verifiers/phalaCloudVerifier.ts
+++ b/packages/verifier/src/verifiers/phalaCloudVerifier.ts
@@ -46,6 +46,24 @@ import {
 import { verifyComposeHash } from "../verification/sourceCodeVerification";
 import { Verifier } from "../verifier";
 
+type ParsedDstackInstance = z.infer<typeof SystemInfoSchema>["instances"][number];
+
+type ValidParsedDstackInstance = ParsedDstackInstance & {
+	quote: string;
+	eventlog: NonNullable<ParsedDstackInstance["eventlog"]>;
+	image_version: string;
+};
+
+function isValidDstackInstance(
+	instance: ParsedDstackInstance,
+): instance is ValidParsedDstackInstance {
+	return (
+		typeof instance.quote === "string" &&
+		Array.isArray(instance.eventlog) &&
+		typeof instance.image_version === "string"
+	);
+}
+
 export class PhalaCloudVerifier extends Verifier {
 	public registrySmartContract?: DstackApp;
 	public appId: AppId;
@@ -253,12 +271,10 @@ export class PhalaCloudVerifier extends Verifier {
 				);
 			}
 
-			// Filter out invalid instances (empty objects when instance is turned off)
+			// Filter out invalid instances before quote normalization. Turned-off
+			// instances can contain null fields even though running instances use strings.
 			const validInstances = parseResult.data.instances.filter(
-				(instance) =>
-					instance.quote !== undefined &&
-					instance.eventlog !== undefined &&
-					instance.image_version !== undefined,
+				isValidDstackInstance,
 			);
 
 			// Check if instances list is empty (instance is turned off)
@@ -276,11 +292,11 @@ export class PhalaCloudVerifier extends Verifier {
 					version: createKmsVersion(parseResult.data.kms_info.version),
 				},
 				instances: validInstances.map((instance) => ({
-					quote: instance.quote!.startsWith("0x")
-						? (instance.quote! as `0x${string}`)
-						: (`0x${instance.quote!}` as `0x${string}`),
-					eventlog: instance.eventlog!,
-					image_version: createImageVersion(instance.image_version!),
+					quote: instance.quote.startsWith("0x")
+						? (instance.quote as `0x${string}`)
+						: (`0x${instance.quote}` as `0x${string}`),
+					eventlog: instance.eventlog,
+					image_version: createImageVersion(instance.image_version),
 				})),
 				kms_guest_agent_info: parseResult.data.kms_guest_agent_info ?? undefined,
 				gateway_guest_agent_info: parseResult.data.gateway_guest_agent_info ?? undefined,


### PR DESCRIPTION
## Summary

Fixes the two Trust Center verifier failure modes identified from production tasks:

1. Phala Cloud attestation responses can include stopped/invalid instances with nullable fields. The verifier schema rejected those responses before it had a chance to filter invalid instances.
2. The `dcap-qvl` binary was built in an image whose GLIBC requirements were newer than the final Bun runtime image, so quote verification failed at runtime.

Closes #50.

## Root causes

### 1. Nullable stopped instances in Phala Cloud attestations

Production failures showed this shape:

```text
Failed to fetch system info from Phala Cloud
→ Failed to parse Phala Cloud response
→ instances[0].quote expected string, received null
```

Root cause:

- Phala Cloud `/attestations` can return `instances[]` entries for stopped/invalid instances.
- Those entries may contain `null` for `quote`, `eventlog`, `tcb_info`, and `image_version`.
- The previous schema used optional string/object fields, which accepts missing fields but rejects explicit `null`.
- The parse failed before verifier runtime filtering, so one stopped instance failed the entire task.

### 2. `dcap-qvl` GLIBC mismatch in the final image

Production failures showed this shape:

```text
/usr/local/bin/dcap-qvl: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

Root cause:

- `dcap-qvl` was compiled in a Rust builder image that produced a binary requiring a newer GLIBC symbol.
- The final runtime image is `oven/bun:1.3.0-slim`, which did not provide that symbol.
- Docker build did not exercise the binary, so the mismatch only appeared when worker tasks executed hardware quote verification.

## Changes

### Schema and verifier runtime

- Accept nullable raw instance fields in `DstackInstanceSchema`:
  - `quote: string | null | undefined`
  - `eventlog: EventLog[] | null | undefined`
  - `tcb_info: object | null | undefined`
  - `image_version: string | null | undefined`
- Add a runtime type guard for valid running instances.
- Filter invalid/stopped instances before quote normalization.
- Normalize quote `0x` prefixes only after a quote is known to be a string.
- Return a clear `has no running instances on Phala Cloud` error when no valid quote-bearing instance remains.

### Docker/runtime packaging

- Build `dcap-qvl` with `rust:1.89.0-slim-bookworm`, matching the final runtime image family.
- Add a final-image smoke check:

```dockerfile
RUN /usr/local/bin/dcap-qvl --help >/dev/null
```

This catches dynamic linker / GLIBC failures during image build.

### Regression tests

Added focused Bun tests covering:

- nullable stopped instance fields are accepted by the raw schema;
- nullable/invalid instances are filtered before quote normalization;
- all-invalid instances produce a handled no-running-instance error.

## Validation

Local checks:

```text
bun test packages/verifier/src/verifiers/phalaCloudVerifier.test.ts   # 3 pass, 0 fail
bun --filter @phala/dstack-verifier test                              # 9 pass, 0 fail
bun --filter @phala/dstack-verifier typecheck                         # pass
bun run typecheck                                                     # pass
/usr/local/bin/dcap-qvl --help                                        # pass
```

CI checks:

```text
typecheck       pass
build-and-push  pass
Vercel          authorization gate
```

The Vercel result is a deployment authorization gate, not a code/test failure.

## Production-shaped E2E evidence

Using Vault-provided production environment variables and live Phala Cloud data, the patched verifier was tested against recent failed task signatures from the last 7 days.

```text
+-------------------------------------+------------------------------+------------------------------+
| production failure class            | root cause                   | patched result               |
+-------------------------------------+------------------------------+------------------------------+
| quote_null_parse_error              | schema rejected null fields  | fixed / handled state        |
| dcap_qvl_glibc_mismatch             | binary/runtime GLIBC mismatch| hardware report OK           |
| gateway_app_id_schema_parse         | Cloud response shape mismatch| sampled current data passes  |
| cloud_system_info_parse_other       | Cloud response shape mismatch| sampled current data passes  |
| unsupported_chain_id_0_old_data     | old data shape               | current live shape passes    |
| no_running_instances                | app has no running instances | expected upstream state      |
| Phala Cloud API 404                 | Cloud API current response   | expected upstream state      |
+-------------------------------------+------------------------------+------------------------------+
```

Additional edge signatures from the `other` bucket were sampled and passed with the patched verifier:

```text
+---------------------------------------------------------------+---------------------------+
| signature                                                     | patched validation         |
+---------------------------------------------------------------+---------------------------+
| Failed to fetch Phala Cloud app info: unknown certificate...   | sourceCode report OK       |
| TLS connection to gateway... before secure TLS...             | sourceCode report OK       |
| Unable to fetch git commit for version v0.5.8...              | no-check report OK         |
+---------------------------------------------------------------+---------------------------+
```

## Deployment expectation

Because production workers are still running the old code until this PR is deployed, old failure classes can continue appearing in existing production task data.

After deployment, expected new-task behavior:

```text
+-----------------------------+----------------------------+
| metric                      | expected after deployment  |
+-----------------------------+----------------------------+
| quote_null_parse_error      | stop increasing            |
| dcap_qvl_glibc_mismatch     | stop increasing            |
| no_running_instances        | may continue               |
| Phala Cloud API 404         | may continue               |
+-----------------------------+----------------------------+
```

Recommended post-deploy check: rerun the production failure classifier on newly created tasks only and confirm the fixed classes stop increasing.
