### PR TITLE
fix: add CA certificates for dcap quote verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,9 +103,9 @@ RUN go install github.com/kvinwang/dstack-mr@latest
 # ------------------------------------------------------------------------------
 FROM deps AS runtime
 
-# Install runtime dependencies for QEMU
+# Install runtime dependencies for QEMU and dcap-qvl TLS trust.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libglib2.0-0 libslirp0 && \
+    apt-get install -y --no-install-recommends ca-certificates libglib2.0-0 libslirp0 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy verification tool binaries
@@ -130,8 +130,10 @@ RUN chmod +x \
     /usr/local/bin/dstack-mr \
     /usr/local/bin/dstack-acpi-tables
 
-# Catch dcap-qvl dynamic linker/glibc mismatches while building the image.
-RUN /usr/local/bin/dcap-qvl --help >/dev/null
+# Catch dcap-qvl dynamic linker/glibc mismatches and missing runtime CA store.
+RUN test -s /etc/ssl/certs/ca-certificates.crt && \
+    grep -q "BEGIN CERTIFICATE" /etc/ssl/certs/ca-certificates.crt && \
+    /usr/local/bin/dcap-qvl --help >/dev/null
 
 # ------------------------------------------------------------------------------
 # Stage 5: Final Image - Application


### PR DESCRIPTION
## Summary
- Install `ca-certificates` in the verifier runtime image so `dcap-qvl verify` can load the system CA store when fetching DCAP collateral.
- Strengthen the Dockerfile smoke check to fail the image build when the runtime CA bundle is missing or empty.

## Root cause
- The post-merge production image fixed the previous `dcap-qvl` GLIBC/linker issue, but live verification tasks failed during quote verification with:
  `unexpected error: No CA certificates were loaded from the system`.
- The runtime image had `dcap-qvl` installed and executable, but lacked the Debian CA bundle required by the verifier's outbound TLS/collateral fetch path.

## Validation
- `git diff --check`
- `bun run typecheck`
- Verified Dockerfile contains `ca-certificates`, retains apt list cleanup, and checks `/etc/ssl/certs/ca-certificates.crt` before `dcap-qvl --help`.

## Notes
- Local Docker daemon is unavailable in this environment, so final image validation should come from the GHCR `build-and-push` workflow.
- No Vault/env changes are required for this fix.
