### PR TITLE
feat(webapp): add dynamic sitemap and robots.txt for SEO

### DIFF
--- a/apps/webapp/src/app/robots.ts
+++ b/apps/webapp/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type {MetadataRoute} from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/'],
+    },
+    sitemap: 'https://trust.phala.com/sitemap.xml',
+  }
+}

--- a/apps/webapp/src/app/sitemap.ts
+++ b/apps/webapp/src/app/sitemap.ts
@@ -1,0 +1,72 @@
+import type {MetadataRoute} from 'next'
+
+import {
+  and,
+  appsTable,
+  createDbConnection,
+  eq,
+  sql,
+  verificationTasksTable,
+} from '@phala/trust-center-db'
+
+import {env} from '@/env'
+import {FEATURED_BUILDERS} from '@/lib/featured-builders'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 3600
+
+const db = createDbConnection(env.DATABASE_POSTGRES_URL)
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = 'https://trust.phala.com'
+
+  const latestTasks = db.$with('latest_tasks').as(
+    db
+      .select({
+        appId: verificationTasksTable.appId,
+        maxCreatedAt: sql<string>`max(${verificationTasksTable.createdAt})`.as(
+          'maxCreatedAt',
+        ),
+      })
+      .from(verificationTasksTable)
+      .where(eq(verificationTasksTable.status, 'completed'))
+      .groupBy(verificationTasksTable.appId),
+  )
+
+  const results = await db
+    .with(latestTasks)
+    .select({
+      id: appsTable.id,
+      updatedAt: appsTable.updatedAt,
+    })
+    .from(appsTable)
+    .innerJoin(latestTasks, eq(appsTable.id, latestTasks.appId))
+    .where(and(eq(appsTable.isPublic, true), eq(appsTable.deleted, false)))
+
+  const appPages: MetadataRoute.Sitemap = results.map((app) => ({
+    url: `${baseUrl}/app/${app.id}`,
+    lastModified: app.updatedAt ? new Date(app.updatedAt) : new Date(),
+    changeFrequency: 'weekly',
+    priority: 0.6,
+  }))
+
+  const builderPages: MetadataRoute.Sitemap = FEATURED_BUILDERS.map(
+    (builder) => ({
+      url: `${baseUrl}/${builder.slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    }),
+  )
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    ...builderPages,
+    ...appPages,
+  ]
+}

--- a/apps/webapp/src/app/sitemap.ts
+++ b/apps/webapp/src/app/sitemap.ts
@@ -1,5 +1,3 @@
-import type {MetadataRoute} from 'next'
-
 import {
   and,
   appsTable,
@@ -8,24 +6,27 @@ import {
   sql,
   verificationTasksTable,
 } from '@phala/trust-center-db'
+import type {MetadataRoute} from 'next'
 
 import {env} from '@/env'
-import {FEATURED_BUILDERS} from '@/lib/featured-builders'
+import {getUsers} from '@/lib/db'
 
-export const dynamic = 'force-dynamic'
 export const revalidate = 3600
 
 const db = createDbConnection(env.DATABASE_POSTGRES_URL)
+const baseUrl = 'https://trust.phala.com'
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value)
+}
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://trust.phala.com'
-
   const latestTasks = db.$with('latest_tasks').as(
     db
       .select({
         appId: verificationTasksTable.appId,
-        maxCreatedAt: sql<string>`max(${verificationTasksTable.createdAt})`.as(
-          'maxCreatedAt',
+        lastCompletedAt: sql<Date>`max(${verificationTasksTable.createdAt})`.as(
+          'lastCompletedAt',
         ),
       })
       .from(verificationTasksTable)
@@ -37,7 +38,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     .with(latestTasks)
     .select({
       id: appsTable.id,
-      updatedAt: appsTable.updatedAt,
+      lastCompletedAt: latestTasks.lastCompletedAt,
     })
     .from(appsTable)
     .innerJoin(latestTasks, eq(appsTable.id, latestTasks.appId))
@@ -45,24 +46,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const appPages: MetadataRoute.Sitemap = results.map((app) => ({
     url: `${baseUrl}/app/${app.id}`,
-    lastModified: app.updatedAt ? new Date(app.updatedAt) : new Date(),
+    lastModified: toDate(app.lastCompletedAt),
     changeFrequency: 'weekly',
     priority: 0.6,
   }))
 
-  const builderPages: MetadataRoute.Sitemap = FEATURED_BUILDERS.map(
-    (builder) => ({
-      url: `${baseUrl}/${builder.slug}`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly' as const,
-      priority: 0.7,
-    }),
-  )
+  const builders = await getUsers()
+  const builderPages: MetadataRoute.Sitemap = builders.map((builder) => ({
+    url: `${baseUrl}/${builder.user}`,
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }))
 
   return [
     {
       url: baseUrl,
-      lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 1.0,
     },


### PR DESCRIPTION
## Summary
- **sitemap.ts**: Queries the database for all public, non-deleted apps with completed verification tasks and generates URLs for ~880+ `/app/{id}` pages plus 19 featured builder pages. Previously trust.phala.com had **no sitemap at all** (returned 404).
- **robots.ts**: Standard Next.js robots metadata — allows crawlers on `/`, disallows `/api/`, points to `trust.phala.com/sitemap.xml`.

## Context
Google Search Console analysis showed only ~208 of ~1,100+ trust.phala.com pages had any Google impressions. With no sitemap.xml, Google was discovering `/app/` pages only through organic link crawling, missing ~80% of them.

## Test plan
- [ ] Verify `trust.phala.com/sitemap.xml` returns valid XML after deploy
- [ ] Verify `trust.phala.com/robots.txt` references the sitemap
- [ ] Confirm sitemap includes featured builder slugs (`/near`, `/phala`, `/primus`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)