### PR TITLE
fix(verifier): invert KMS in TEE / Onchain KMS relationship condition

### DIFF
--- a/packages/verifier/src/verificationService.ts
+++ b/packages/verifier/src/verificationService.ts
@@ -128,14 +128,14 @@ export class VerificationService {
    * Configure relationships between verifiers
    */
   private configureVerifierRelationships(systemInfo: SystemInfo): void {
-    const hasOnchainKms = supportsOnchainKms(systemInfo.kms_info.version)
+    const kmsInTee = !supportsOnchainKms(systemInfo.kms_info.version)
 
     const relationships: ObjectRelationship[] = [
       // KMS -> Gateway relationships
       {
         sourceObjectId: 'kms-main',
         targetObjectId: 'gateway-main',
-        ...(hasOnchainKms
+        ...(kmsInTee
           ? {
               sourceField: 'gateway_app_id',
               targetField: 'app_id',
@@ -145,7 +145,7 @@ export class VerificationService {
       {
         sourceObjectId: 'kms-main',
         targetObjectId: 'gateway-main',
-        ...(hasOnchainKms
+        ...(kmsInTee
           ? {
               sourceField: 'cert_pubkey',
               targetField: 'app_cert',
@@ -156,7 +156,7 @@ export class VerificationService {
       {
         sourceObjectId: 'kms-main',
         targetObjectId: 'app-main',
-        ...(hasOnchainKms
+        ...(kmsInTee
           ? {
               sourceField: 'cert_pubkey',
               targetField: 'app_cert',


### PR DESCRIPTION
The cert_pubkey↔app_cert and gateway_app_id↔app_id cross-verifier relationships only make sense when KMS runs inside the same TEE as App/Gateway (legacy < 0.5.3), because they share the same quote and certificate. Onchain KMS (>= 0.5.3) is an independent on-chain entity with its own quote/cert and should not create these relationships.

Previously the code applied these relationships for onchain KMS and skipped them for KMS in TEE — the opposite of what the logic requires.