### PR TITLE
fix: include verification failures in error message

### DIFF
--- a/apps/server/src/services/queue.ts
+++ b/apps/server/src/services/queue.ts
@@ -211,11 +211,18 @@ export const createQueueService = (
         ])
 
         if (!verificationResult.success) {
-          throw new Error(
-            verificationResult.errors
-              .map((error: {message: string}) => error.message)
-              .join(', '),
-          )
+          const allMessages = [
+            ...verificationResult.errors.map((error: {message: string}) => error.message),
+            ...verificationResult.failures.map((f: {error: string}) => f.error),
+          ].filter(Boolean)
+          
+          console.error('[QUEUE] Verification result details:', {
+            errors: verificationResult.errors,
+            failures: verificationResult.failures,
+            success: verificationResult.success,
+          })
+          
+          throw new Error(allMessages.join(', ') || 'Verification failed')
         }
 
         const processingTimeMs = Date.now() - startTime


### PR DESCRIPTION
Previously only errors were included in the thrown message, but verification failures (like OS mismatch) were stored in failures array. Now includes both errors and failures in the error message, and logs the full verification result details for debugging.