### PR TITLE
fix(verifier): use matching QEMU builder for RTMR0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN cp /app/dcap-qvl/Cargo.lock /app/dcap-qvl/cli/Cargo.lock && \
 FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS qemu-builder
 COPY packages/verifier/dstack-mr-cli/shared /build
 WORKDIR /build
-ARG QEMU_REV=d98440811192c08eafc07c7af110593c6b3758ff
+ARG QEMU_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
@@ -67,7 +67,7 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 
 RUN git clone https://github.com/kvinwang/qemu-tdx.git \
-    --depth 1 --branch passthrough-dump-acpi --single-branch && \
+    --depth 1 --branch dstack-qemu-9.2.1 --single-branch && \
     cd qemu-tdx && \
     git fetch --depth 1 origin ${QEMU_REV} && \
     git checkout ${QEMU_REV} && \


### PR DESCRIPTION
## Summary
- Switch dstack-acpi-tables build to the QEMU 9.2.1 branch used by upstream dstack verifier builder
- Pin QEMU to dbcec07c0854bf873d346a09e87e4c993ccf2633 so RTMR0 ACPI measurement matches current dstack apps

## Checks
- bun run typecheck
- git diff --check
- git ls-remote verified the QEMU branch and pinned revision

## Notes
- Local docker build could not run because this environment cannot access the Docker daemon socket.
- prek is unavailable because no prek.toml or .pre-commit-config.yaml exists in this repository.