### PR TITLE
Fix KMS OS image detection

### DIFF
--- a/packages/verifier/src/verifiers/kmsVerifier.ts
+++ b/packages/verifier/src/verifiers/kmsVerifier.ts
@@ -160,12 +160,32 @@ export abstract class KmsVerifier extends Verifier {
 		const appInfo = await this.getAppInfo();
 		const failures: VerificationFailure[] = [];
 
-		// Extract version from KMS info and construct image folder name
+		// Determine the OS image folder name
+		// Priority: vm_config.image (actual running OS) > kms_info.version (KMS software version)
 		const { extractVersionNumber, ensureDstackImage } = await import(
 			"../utils/imageDownloader"
 		);
-		const version = extractVersionNumber(this.kmsInfo.version);
-		const imageFolderName = `dstack-${version}`;
+		let imageFolderName: string;
+
+		// Check if vm_config has image field (use1/use2 format with spec_version)
+		const vmConfig = appInfo.vm_config;
+		if ('spec_version' in vmConfig && 'image' in vmConfig && vmConfig.image) {
+			// Use image name from vm_config (e.g., "dstack-0.5.8-6427f4f5")
+			// Extract base image name by removing the git hash suffix
+			const imageName = vmConfig.image;
+			// Match pattern: dstack-<version>-<hash> or dstack-dev-<version>-<hash>
+			const imageMatch = imageName.match(/^(dstack(?:-dev)?-\d+(?:\.\d+)+)(?:-|$)/);
+			if (imageMatch?.[1]) {
+				imageFolderName = imageMatch[1];
+			} else {
+				// Fallback: use the full image name
+				imageFolderName = imageName;
+			}
+		} else {
+			// Fallback: extract version from KMS info
+			const version = extractVersionNumber(this.kmsInfo.version);
+			imageFolderName = `dstack-${version}`;
+		}
 
 		// Ensure image is downloaded
 		await ensureDstackImage(imageFolderName);

--- a/packages/verifier/src/verifiers/phalaCloudKmsVerifier.ts
+++ b/packages/verifier/src/verifiers/phalaCloudKmsVerifier.ts
@@ -45,6 +45,29 @@ export class PhalaCloudKmsVerifier extends KmsVerifier {
   }
 
   protected override async getQuote(): Promise<QuoteData> {
+    const guestAgentInfo = this.systemInfo.kms_guest_agent_info
+    const leafCert = guestAgentInfo?.app_certificates?.find(
+      (cert) => !cert.is_ca,
+    )
+
+    if (guestAgentInfo && leafCert?.quote) {
+      if (this.registrySmartContract) {
+        const contractKmsInfo = await this.registrySmartContract.kmsInfo()
+        this.certificateAuthorityPublicKey = contractKmsInfo.caPubkey
+      } else {
+        this.certificateAuthorityPublicKey = HARDCODED_KMS_INFO.caPubkey
+      }
+
+      const rawQuote = leafCert.quote
+      const quote = (
+        rawQuote.startsWith('0x') ? rawQuote : `0x${rawQuote}`
+      ) as `0x${string}`
+      return {
+        quote,
+        eventlog: guestAgentInfo.tcb_info.event_log,
+      }
+    }
+
     if (this.registrySmartContract) {
       return super.getQuote()
     }
@@ -58,22 +81,6 @@ export class PhalaCloudKmsVerifier extends KmsVerifier {
     }
 
     this.certificateAuthorityPublicKey = HARDCODED_KMS_INFO.caPubkey
-
-    const guestAgentInfo = this.systemInfo.kms_guest_agent_info
-    const leafCert = guestAgentInfo?.app_certificates?.find(
-      (cert) => !cert.is_ca,
-    )
-
-    if (guestAgentInfo && leafCert?.quote) {
-      const rawQuote = leafCert.quote
-      const quote = (
-        rawQuote.startsWith('0x') ? rawQuote : `0x${rawQuote}`
-      ) as `0x${string}`
-      return {
-        quote,
-        eventlog: guestAgentInfo.tcb_info.event_log,
-      }
-    }
 
     const eventLogBuffer = Buffer.from(
       HARDCODED_KMS_INFO.eventlog.replace('0x', ''),


### PR DESCRIPTION
## Summary
- Use the KMS guest agent vm_config.image as the source of truth for KMS OS image verification
- Keep live KMS quote/eventlog and guest agent app info on the same data source
- Fall back to the existing KMS version and legacy hardcoded data paths when live guest agent data is unavailable

## Verification
- bun run typecheck
- prek attempted, but no prek.toml or .pre-commit-config.yaml exists in this repository