### PR TITLE
Skip legacy app OS checks and add MR mismatch diagnostics

### DIFF
--- a/packages/verifier/src/verification/osVerification.ts
+++ b/packages/verifier/src/verification/osVerification.ts
@@ -27,6 +27,64 @@ function getDStackImagesBasePath(): string {
   return path.join(import.meta.dirname, '../../external/dstack-images')
 }
 
+type MeasurementRegisters = {
+  mrtd: string
+  rtmr0: string
+  rtmr1: string
+  rtmr2: string
+}
+
+type MeasurementRegisterName = keyof MeasurementRegisters
+
+export interface MeasurementRegisterMismatch {
+  register: MeasurementRegisterName
+  expected: string
+  calculated: string
+}
+
+export interface OSVerificationResult {
+  isValid: boolean
+  tool: 'dstack-mr-cli' | 'dstack-mr'
+  measurementResult: MeasurementRegisters
+  mismatches: MeasurementRegisterMismatch[]
+}
+
+/**
+ * Measures DStack OS images and compares with expected TCB values.
+ * Automatically selects the appropriate measurement tool based on vm_config format:
+ * - Full VmConfig (with spec_version): uses modern Rust-based dstack-mr-cli
+ * - BasicVmConfig: uses legacy Go-based dstack-mr (reads metadata.json)
+ *
+ * @param appInfo - Application information containing VM config
+ * @param imageFolderName - Name of the image folder to use (required)
+ * @returns Promise resolving to detailed verification result
+ */
+export async function verifyOSIntegrityDetailed(
+  appInfo: AppInfo,
+  imageFolderName: string,
+): Promise<OSVerificationResult> {
+  if (isFullVmConfig(appInfo.vm_config)) {
+    const measurementResult = await measureDstackImages({
+      image_folder: path.join(getDStackImagesBasePath(), imageFolderName),
+      vm_config: appInfo.vm_config,
+    })
+    return buildOSVerificationResult(
+      measurementResult,
+      appInfo.tcb_info,
+      'dstack-mr-cli',
+    )
+  }
+
+  const measurementResult = await measureDstackImagesLegacy({
+    image_folder: path.join(getDStackImagesBasePath(), imageFolderName),
+  })
+  return buildOSVerificationResult(
+    measurementResult,
+    appInfo.tcb_info,
+    'dstack-mr',
+  )
+}
+
 /**
  * Measures DStack OS images and compares with expected TCB values.
  * Automatically selects the appropriate measurement tool based on vm_config format:
@@ -41,23 +99,30 @@ export async function verifyOSIntegrity(
   appInfo: AppInfo,
   imageFolderName: string,
 ): Promise<boolean> {
-  // Check if vm_config has full VmConfig fields using type guard
-  if (isFullVmConfig(appInfo.vm_config)) {
-    // Full VmConfig (>= 0.5.3) - use modern Rust-based measurement
-    const measurementResult = await measureDstackImages({
-      image_folder: path.join(getDStackImagesBasePath(), imageFolderName),
-      vm_config: appInfo.vm_config,
-    })
-    const expectedTcb = appInfo.tcb_info
-    return compareMeasurementRegisters(measurementResult, expectedTcb)
-  } else {
-    // BasicVmConfig (0.5.0-0.5.2) - use legacy Go-based measurement
-    const measurementResult = await measureDstackImagesLegacy({
-      image_folder: path.join(getDStackImagesBasePath(), imageFolderName),
-    })
-    const expectedTcb = appInfo.tcb_info
-    return compareMeasurementRegisters(measurementResult, expectedTcb)
-  }
+  return (await verifyOSIntegrityDetailed(appInfo, imageFolderName)).isValid
+}
+
+/**
+ * Measures DStack OS images for legacy versions using the Go-based dstack-mr tool.
+ * This tool reads metadata.json and doesn't require vm_config parameters.
+ *
+ * @param appInfo - Application information (vm_config not used)
+ * @param imageFolderName - Name of the image folder to use for legacy versions (required)
+ * @returns Promise resolving to detailed verification result
+ */
+export async function verifyOSIntegrityLegacyDetailed(
+  appInfo: AppInfo,
+  imageFolderName: string,
+): Promise<OSVerificationResult> {
+  const measurementResult = await measureDstackImagesLegacy({
+    image_folder: path.join(getDStackImagesBasePath(), imageFolderName),
+  })
+
+  return buildOSVerificationResult(
+    measurementResult,
+    appInfo.tcb_info,
+    'dstack-mr',
+  )
 }
 
 /**
@@ -72,12 +137,40 @@ export async function verifyOSIntegrityLegacy(
   appInfo: AppInfo,
   imageFolderName: string,
 ): Promise<boolean> {
-  const measurementResult = await measureDstackImagesLegacy({
-    image_folder: path.join(getDStackImagesBasePath(), imageFolderName),
-  })
+  return (await verifyOSIntegrityLegacyDetailed(appInfo, imageFolderName))
+    .isValid
+}
 
-  const expectedTcb = appInfo.tcb_info
-  return compareMeasurementRegisters(measurementResult, expectedTcb)
+export function formatOSVerificationFailure(
+  imageFolderName: string,
+  result: OSVerificationResult,
+): string {
+  const mismatches = result.mismatches
+    .map(
+      (mismatch) =>
+        `${mismatch.register}: expected=${mismatch.expected} calculated=${mismatch.calculated}`,
+    )
+    .join('; ')
+
+  return `Operating system verification failed: Measurement registers (MRTD, RTMR0-2) do not match expected values (image=${imageFolderName}, tool=${result.tool}, mismatches=${mismatches})`
+}
+
+function buildOSVerificationResult(
+  measurementResult: MeasurementRegisters,
+  expectedTcb: TcbInfo,
+  tool: OSVerificationResult['tool'],
+): OSVerificationResult {
+  const mismatches = compareMeasurementRegisters(
+    measurementResult,
+    expectedTcb,
+  )
+
+  return {
+    isValid: mismatches.length === 0,
+    tool,
+    measurementResult,
+    mismatches,
+  }
 }
 
 /**
@@ -85,21 +178,28 @@ export async function verifyOSIntegrityLegacy(
  *
  * @param measurementResult - Result from DStack measurement tool
  * @param expectedTcb - Expected TCB information
- * @returns True if all registers match
+ * @returns Mismatched registers
  */
 function compareMeasurementRegisters(
-  measurementResult: {
-    mrtd: string
-    rtmr0: string
-    rtmr1: string
-    rtmr2: string
-  },
+  measurementResult: MeasurementRegisters,
   expectedTcb: TcbInfo,
-): boolean {
-  return (
-    measurementResult.mrtd === expectedTcb.mrtd &&
-    measurementResult.rtmr0 === expectedTcb.rtmr0 &&
-    measurementResult.rtmr1 === expectedTcb.rtmr1 &&
-    measurementResult.rtmr2 === expectedTcb.rtmr2
+): MeasurementRegisterMismatch[] {
+  const registerNames: MeasurementRegisterName[] = [
+    'mrtd',
+    'rtmr0',
+    'rtmr1',
+    'rtmr2',
+  ]
+
+  return registerNames.flatMap((register) =>
+    measurementResult[register] === expectedTcb[register]
+      ? []
+      : [
+          {
+            register,
+            expected: expectedTcb[register],
+            calculated: measurementResult[register],
+          },
+        ],
   )
 }

--- a/packages/verifier/src/verifiers/gatewayVerifier.ts
+++ b/packages/verifier/src/verifiers/gatewayVerifier.ts
@@ -31,7 +31,10 @@ import {
   verifyTeeControlledKey,
 } from '../verification/domainVerification'
 import {isUpToDate, verifyTeeQuote} from '../verification/hardwareVerification'
-import {verifyOSIntegrity} from '../verification/osVerification'
+import {
+  formatOSVerificationFailure,
+  verifyOSIntegrityDetailed,
+} from '../verification/osVerification'
 import {verifyComposeHash} from '../verification/sourceCodeVerification'
 import {type OwnDomain, Verifier} from '../verifier'
 
@@ -215,7 +218,8 @@ export class GatewayVerifier extends Verifier implements OwnDomain {
     // Ensure image is downloaded
     await ensureDstackImage(imageFolderName)
 
-    const isValid = await verifyOSIntegrity(appInfo, imageFolderName)
+    const osVerification = await verifyOSIntegrityDetailed(appInfo, imageFolderName)
+    const isValid = osVerification.isValid
 
     // Generate DataObjects for Gateway OS verification
     const dataObjects = this.dataObjectGenerator.generateOSDataObjects(appInfo)
@@ -226,8 +230,7 @@ export class GatewayVerifier extends Verifier implements OwnDomain {
     if (!isValid) {
       failures.push({
         componentId: 'gateway-main',
-        error:
-          'Operating system verification failed: Measurement registers (MRTD, RTMR0-2) do not match expected values',
+        error: formatOSVerificationFailure(imageFolderName, osVerification),
       })
     }
 

--- a/packages/verifier/src/verifiers/kmsVerifier.ts
+++ b/packages/verifier/src/verifiers/kmsVerifier.ts
@@ -15,7 +15,10 @@ import {
 	isUpToDate,
 	verifyTeeQuote,
 } from "../verification/hardwareVerification";
-import { verifyOSIntegrity } from "../verification/osVerification";
+import {
+	formatOSVerificationFailure,
+	verifyOSIntegrityDetailed,
+} from "../verification/osVerification";
 import { verifyComposeHash } from "../verification/sourceCodeVerification";
 import { Verifier } from "../verifier";
 
@@ -190,7 +193,8 @@ export abstract class KmsVerifier extends Verifier {
 		// Ensure image is downloaded
 		await ensureDstackImage(imageFolderName);
 
-		const isValid = await verifyOSIntegrity(appInfo, imageFolderName);
+		const osVerification = await verifyOSIntegrityDetailed(appInfo, imageFolderName);
+		const isValid = osVerification.isValid;
 
 		// Generate DataObjects for KMS OS verification
 		const dataObjects = this.dataObjectGenerator.generateOSDataObjects(appInfo);
@@ -201,8 +205,7 @@ export abstract class KmsVerifier extends Verifier {
 		if (!isValid) {
 			failures.push({
 				componentId: "kms-main",
-				error:
-					"Operating system verification failed: Measurement registers (MRTD, RTMR0-2) do not match expected values",
+				error: formatOSVerificationFailure(imageFolderName, osVerification),
 			});
 		}
 

--- a/packages/verifier/src/verifiers/phalaCloudVerifier.ts
+++ b/packages/verifier/src/verifiers/phalaCloudVerifier.ts
@@ -39,10 +39,7 @@ import {
 	isUpToDate,
 	verifyTeeQuote,
 } from "../verification/hardwareVerification";
-import {
-	verifyOSIntegrity,
-	verifyOSIntegrityLegacy,
-} from "../verification/osVerification";
+import { verifyOSIntegrity } from "../verification/osVerification";
 import { verifyComposeHash } from "../verification/sourceCodeVerification";
 import { Verifier } from "../verifier";
 
@@ -538,9 +535,10 @@ export class PhalaCloudVerifier extends Verifier {
 		const { ensureDstackImage } = await import("../utils/imageDownloader");
 		await ensureDstackImage(imageFolderName);
 
+		// Legacy app OS measurements cannot be reliably recomputed.
 		const isValid = supportsOnchainKms(this.systemInfo.kms_info.version)
 			? await verifyOSIntegrity(appInfo, imageFolderName)
-			: await verifyOSIntegrityLegacy(appInfo, imageFolderName);
+			: true;
 
 		// Generate DataObjects for App OS verification
 		const dataObjects = this.dataObjectGenerator.generateOSDataObjects(

--- a/packages/verifier/src/verifiers/phalaCloudVerifier.ts
+++ b/packages/verifier/src/verifiers/phalaCloudVerifier.ts
@@ -39,7 +39,10 @@ import {
 	isUpToDate,
 	verifyTeeQuote,
 } from "../verification/hardwareVerification";
-import { verifyOSIntegrity } from "../verification/osVerification";
+import {
+	formatOSVerificationFailure,
+	verifyOSIntegrityDetailed,
+} from "../verification/osVerification";
 import { verifyComposeHash } from "../verification/sourceCodeVerification";
 import { Verifier } from "../verifier";
 
@@ -536,9 +539,10 @@ export class PhalaCloudVerifier extends Verifier {
 		await ensureDstackImage(imageFolderName);
 
 		// Legacy app OS measurements cannot be reliably recomputed.
-		const isValid = supportsOnchainKms(this.systemInfo.kms_info.version)
-			? await verifyOSIntegrity(appInfo, imageFolderName)
-			: true;
+		const osVerification = supportsOnchainKms(this.systemInfo.kms_info.version)
+			? await verifyOSIntegrityDetailed(appInfo, imageFolderName)
+			: null;
+		const isValid = osVerification?.isValid ?? true;
 
 		// Generate DataObjects for App OS verification
 		const dataObjects = this.dataObjectGenerator.generateOSDataObjects(
@@ -549,11 +553,10 @@ export class PhalaCloudVerifier extends Verifier {
 			this.createDataObject(obj);
 		});
 
-		if (!isValid) {
+		if (!isValid && osVerification) {
 			failures.push({
 				componentId: "app-main",
-				error:
-					"Operating system verification failed: Measurement registers (MRTD, RTMR0-2) do not match expected values",
+				error: formatOSVerificationFailure(imageFolderName, osVerification),
 			});
 		}
 


### PR DESCRIPTION
## Summary
- Skip OS measurement comparison for legacy app versions where measurements cannot be reliably recomputed
- Keep generating App OS data objects for legacy reports
- Add detailed OS measurement mismatch diagnostics for App, KMS, and Gateway failures
- Include image folder, measurement tool, mismatched register, expected value, and calculated value in OS failure messages

## Verification
- bun run typecheck
- prek attempted, but no prek.toml or .pre-commit-config.yaml exists in this repository