### PR TITLE
fix(server): batch profile upserts

### DIFF
--- a/apps/server/src/services/profileService.ts
+++ b/apps/server/src/services/profileService.ts
@@ -104,20 +104,26 @@ export function createProfileService(
       updatedAt: p.updated_at ? new Date(p.updated_at) : null,
     }))
 
-    // Upsert all profiles in one operation
-    await db
-      .insert(profilesTable)
-      .values(values)
-      .onConflictDoUpdate({
-        target: [profilesTable.entityType, profilesTable.entityId],
-        set: {
-          displayName: sql`EXCLUDED.display_name`,
-          avatarUrl: sql`EXCLUDED.avatar_url`,
-          description: sql`EXCLUDED.description`,
-          customDomain: sql`EXCLUDED.custom_domain`,
-          updatedAt: sql`EXCLUDED.updated_at`,
-        },
-      })
+    const BATCH_SIZE = 1000
+
+    // Process in batches to stay below the PostgreSQL parameter limit
+    for (let i = 0; i < values.length; i += BATCH_SIZE) {
+      const batch = values.slice(i, i + BATCH_SIZE)
+
+      await db
+        .insert(profilesTable)
+        .values(batch)
+        .onConflictDoUpdate({
+          target: [profilesTable.entityType, profilesTable.entityId],
+          set: {
+            displayName: sql`EXCLUDED.display_name`,
+            avatarUrl: sql`EXCLUDED.avatar_url`,
+            description: sql`EXCLUDED.description`,
+            customDomain: sql`EXCLUDED.custom_domain`,
+            updatedAt: sql`EXCLUDED.updated_at`,
+          },
+        })
+    }
 
     console.log(
       `[PROFILE] Profile sync completed: ${values.length} profiles synced (${toDelete.length} deleted)`,


### PR DESCRIPTION
## Summary
- split profile upserts into batches of 1,000 records
- preserve the existing conflict update behavior and sync result logging
- keep each insert below the database parameter limit

## Context
The full profile sync generated 238,272 parameters in one insert, exceeding the 65,534 parameter limit and failing with `MAX_PARAMETERS_EXCEEDED`.

A 1,000-profile batch generates 8,000 parameters.

## Validation
- `bun run typecheck`
- `bunx biome check apps/server/src/services/profileService.ts`
- exercised `syncProfiles()` with 2,501 profiles and verified batch sizes of 1,000, 1,000, and 501
- generated the real Drizzle insert SQL for 1,000 profiles and verified it contains 8,000 parameters
- `git diff --check`
